### PR TITLE
Editable metadata #163

### DIFF
--- a/src/front_end/src/components/SearchPreviewDrawer.vue
+++ b/src/front_end/src/components/SearchPreviewDrawer.vue
@@ -9,9 +9,21 @@
  */
 
 import { computed, ref, watch } from 'vue'
-import { X, StarsIcon, CalendarDays, HardDrive, FileType2, ExternalLink, Pencil, Save, XCircle, CheckCircle, AlertCircle } from 'lucide-vue-next'
+import {
+  X,
+  StarsIcon,
+  CalendarDays,
+  HardDrive,
+  FileType2,
+  ExternalLink,
+  Pencil,
+  Save,
+  XCircle,
+  CheckCircle,
+  AlertCircle
+} from 'lucide-vue-next'
 import { useSearchMetadata } from '@/composables/useSearchMetadata'
-import {hasRole} from "@/utils/auth";
+import { hasRole } from '@/utils/auth'
 
 /* Props received from parent component (SearchView) */
 const props = defineProps({
@@ -29,11 +41,11 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
 
 /* Base URL for API requests */
 const API_BASE_URL = import.meta.env.API_BASE_URL?.replace(/\/$/, '') ?? ''
- 
-/* ── Edit mode state ── */
+
+/* Edit mode state */
 const isEditing = ref(false)
 const isSaving = ref(false)
- 
+
 /* Editable field values (populated when entering edit mode) */
 const editFields = ref({
   title: '',
@@ -41,14 +53,14 @@ const editFields = ref({
   created: '',
   size: ''
 })
- 
+
 /* Status toast for save feedback */
 const toast = ref({ visible: false, success: true, message: '' })
 let toastTimer = null
- 
+
 /* Check if the current user is allowed to edit metadata */
 const canEdit = computed(() => hasRole('admin'))
- 
+
 /* Enter edit mode: snapshot current values into the form */
 const startEditing = () => {
   editFields.value = {
@@ -59,17 +71,17 @@ const startEditing = () => {
   }
   isEditing.value = true
 }
- 
+
 /* Cancel editing: reset form and exit edit mode */
 const cancelEditing = () => {
   isEditing.value = false
   editFields.value = { title: '', type: '', created: '', size: '' }
 }
- 
+
 /* Save metadata changes */
 const saveMetadata = async () => {
   isSaving.value = true
- 
+
   try {
     // TODO: Replace with real endpoint when backend supports metadata updates.
     // The endpoint should accept the document identifier and updated fields.
@@ -81,11 +93,11 @@ const saveMetadata = async () => {
         metadata: { ...editFields.value }
       })
     })
- 
+
     if (!res.ok) {
       throw new Error(`Server responded with ${res.status}`)
     }
- 
+
     showToast(true, 'Metadata updated successfully.')
     isEditing.value = false
   } catch (err) {
@@ -94,7 +106,7 @@ const saveMetadata = async () => {
     isSaving.value = false
   }
 }
- 
+
 /* Toast helper */
 const showToast = (success, message) => {
   if (toastTimer) clearTimeout(toastTimer)
@@ -103,7 +115,7 @@ const showToast = (success, message) => {
     toast.value.visible = false
   }, 4000)
 }
- 
+
 /* Reset edit state when a different document is selected or drawer closes */
 watch(
   () => [props.selectedFile, props.open],
@@ -129,7 +141,6 @@ watch(
 
     <!-- Main content area of the preview drawer -->
     <div class="preview-body">
-
       <Transition name="toast-fade">
         <div v-if="toast.visible" :class="['toast', toast.success ? 'toast-success' : 'toast-error']">
           <CheckCircle v-if="toast.success" :size="16" />
@@ -161,14 +172,14 @@ watch(
       <section class="panel-section">
         <div class="section-header">
           <p class="section-title">TECHNICAL METADATA</p>
- 
+
           <!-- Edit button – only visible to authorized users when not already editing -->
           <button v-if="canEdit && !isEditing" class="edit-btn" type="button" title="Edit metadata" @click="startEditing">
             <Pencil :size="14" />
             Edit
           </button>
         </div>
- 
+
         <!-- ── Read-only metadata grid ── -->
         <div v-if="!isEditing" class="meta-grid">
           <div class="meta-cell">
@@ -199,7 +210,7 @@ watch(
             <label class="edit-label" for="edit-type">Format</label>
             <input id="edit-type" v-model="editFields.type" class="edit-input" type="text" placeholder="e.g. PDF Document" />
           </div>
- 
+
           <!-- Save / Cancel actions -->
           <div class="edit-actions">
             <button class="action-btn cancel-btn" type="button" :disabled="isSaving" @click="cancelEditing">
@@ -318,7 +329,7 @@ watch(
   font-weight: 700;
   display: inline-flex;
   align-items: center;
-  margin : 0;
+  margin: 0;
 }
 
 .section-header {
@@ -415,25 +426,25 @@ watch(
   font-weight: 600;
   cursor: pointer;
 }
- 
+
 .edit-btn:hover {
   border-color: #7c3aed;
   color: #7c3aed;
   background: #faf5ff;
 }
- 
+
 .meta-edit-form {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
- 
+
 .edit-field {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
- 
+
 .edit-label {
   font-size: 0.7rem;
   font-weight: 700;
@@ -441,7 +452,7 @@ watch(
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
- 
+
 .edit-input {
   border: 1px solid #d8dee7;
   border-radius: 8px;
@@ -452,25 +463,25 @@ watch(
   outline: none;
   font-family: inherit;
 }
- 
+
 .edit-input:focus {
   border-color: #7c3aed;
   box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.12);
 }
- 
+
 .edit-title {
   margin-top: 2rem;
   text-align: center;
   font-size: 1.25rem;
   font-weight: 600;
 }
- 
+
 .edit-actions {
   display: flex;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
- 
+
 .action-btn {
   flex: 1;
   display: inline-flex;
@@ -483,33 +494,33 @@ watch(
   font-weight: 600;
   cursor: pointer;
 }
- 
+
 .cancel-btn {
   border: 1px solid #d8dee7;
   background: #f8fafc;
   color: #475569;
 }
- 
+
 .cancel-btn:hover:not(:disabled) {
   background: #f1f5f9;
   border-color: #94a3b8;
 }
- 
+
 .save-btn {
   border: none;
   background: linear-gradient(135deg, #5b21b6 0%, #7c3aed 100%);
   color: #ffffff;
 }
- 
+
 .save-btn:hover:not(:disabled) {
   opacity: 0.92;
 }
- 
+
 .action-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
- 
+
 .toast {
   display: flex;
   align-items: center;
@@ -520,24 +531,26 @@ watch(
   font-weight: 600;
   margin-bottom: 0.75rem;
 }
- 
+
 .toast-success {
   background: #ecfdf5;
   color: #065f46;
   border: 1px solid #a7f3d0;
 }
- 
+
 .toast-error {
   background: #fef2f2;
   color: #991b1b;
   border: 1px solid #fecaca;
 }
- 
+
 .toast-fade-enter-active,
 .toast-fade-leave-active {
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
- 
+
 .toast-fade-enter-from,
 .toast-fade-leave-to {
   opacity: 0;

--- a/src/front_end/src/components/SearchPreviewDrawer.vue
+++ b/src/front_end/src/components/SearchPreviewDrawer.vue
@@ -8,8 +8,10 @@
  * <SearchPreviewDrawer :open="isPreviewOpen" :selected-file="selectedFile" :selected-match="selectedMatch" :matches="matches" @close="closePreview" />
  */
 
-import { X, StarsIcon, CalendarDays, HardDrive, FileType2, ExternalLink } from 'lucide-vue-next'
+import { computed, ref, watch } from 'vue'
+import { X, StarsIcon, CalendarDays, HardDrive, FileType2, ExternalLink, Pencil, Save, XCircle, CheckCircle, AlertCircle } from 'lucide-vue-next'
 import { useSearchMetadata } from '@/composables/useSearchMetadata'
+import {hasRole} from "@/utils/auth";
 
 /* Props received from parent component (SearchView) */
 const props = defineProps({
@@ -24,6 +26,92 @@ const emit = defineEmits(['close'])
 
 /* Use custom composable to extract metadata for the selected file */
 const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } = useSearchMetadata(props)
+
+/* Base URL for API requests */
+const API_BASE_URL = import.meta.env.API_BASE_URL?.replace(/\/$/, '') ?? ''
+ 
+/* ── Edit mode state ── */
+const isEditing = ref(false)
+const isSaving = ref(false)
+ 
+/* Editable field values (populated when entering edit mode) */
+const editFields = ref({
+  title: '',
+  type: '',
+  created: '',
+  size: ''
+})
+ 
+/* Status toast for save feedback */
+const toast = ref({ visible: false, success: true, message: '' })
+let toastTimer = null
+ 
+/* Check if the current user is allowed to edit metadata */
+const canEdit = computed(() => hasRole('admin'))
+ 
+/* Enter edit mode: snapshot current values into the form */
+const startEditing = () => {
+  editFields.value = {
+    title: previewTitle.value || '',
+    type: previewType.value || '',
+    created: previewCreatedAt.value || '',
+    size: previewSize.value || ''
+  }
+  isEditing.value = true
+}
+ 
+/* Cancel editing: reset form and exit edit mode */
+const cancelEditing = () => {
+  isEditing.value = false
+  editFields.value = { title: '', type: '', created: '', size: '' }
+}
+ 
+/* Save metadata changes */
+const saveMetadata = async () => {
+  isSaving.value = true
+ 
+  try {
+    // TODO: Replace with real endpoint when backend supports metadata updates.
+    // The endpoint should accept the document identifier and updated fields.
+    const res = await fetch(`${API_BASE_URL}/metadata`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: props.selectedFile,
+        metadata: { ...editFields.value }
+      })
+    })
+ 
+    if (!res.ok) {
+      throw new Error(`Server responded with ${res.status}`)
+    }
+ 
+    showToast(true, 'Metadata updated successfully.')
+    isEditing.value = false
+  } catch (err) {
+    showToast(false, `Update failed: ${err.message}`)
+  } finally {
+    isSaving.value = false
+  }
+}
+ 
+/* Toast helper */
+const showToast = (success, message) => {
+  if (toastTimer) clearTimeout(toastTimer)
+  toast.value = { visible: true, success, message }
+  toastTimer = setTimeout(() => {
+    toast.value.visible = false
+  }, 4000)
+}
+ 
+/* Reset edit state when a different document is selected or drawer closes */
+watch(
+  () => [props.selectedFile, props.open],
+  () => {
+    cancelEditing()
+    toast.value.visible = false
+  }
+)
 </script>
 
 <template>
@@ -41,10 +129,23 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
 
     <!-- Main content area of the preview drawer -->
     <div class="preview-body">
+
+      <Transition name="toast-fade">
+        <div v-if="toast.visible" :class="['toast', toast.success ? 'toast-success' : 'toast-error']">
+          <CheckCircle v-if="toast.success" :size="16" />
+          <AlertCircle v-else :size="16" />
+          <span>{{ toast.message }}</span>
+        </div>
+      </Transition>
+
+      <template v-if="isEditing">
+        <input v-model="editFields.title" class="edit-input edit-title" type="text" placeholder="Document title" />
+      </template>
+
       <h3 class="preview-title">{{ previewTitle }}</h3>
 
       <div class="tag-row">
-        <span class="tag">{{ previewType }}</span>
+        <span class="tag">{{ isEditing ? editFields.type || previewType : previewType }}</span>
       </div>
 
       <!-- AI Summary section -->
@@ -58,8 +159,18 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
 
       <!-- Technical Metadata section -->
       <section class="panel-section">
-        <p class="section-title">TECHNICAL METADATA</p>
-        <div class="meta-grid">
+        <div class="section-header">
+          <p class="section-title">TECHNICAL METADATA</p>
+ 
+          <!-- Edit button – only visible to authorized users when not already editing -->
+          <button v-if="canEdit && !isEditing" class="edit-btn" type="button" title="Edit metadata" @click="startEditing">
+            <Pencil :size="14" />
+            Edit
+          </button>
+        </div>
+ 
+        <!-- ── Read-only metadata grid ── -->
+        <div v-if="!isEditing" class="meta-grid">
           <div class="meta-cell">
             <span>Created</span>
             <p><CalendarDays :size="13" /> {{ previewCreatedAt }}</p>
@@ -71,6 +182,34 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
           <div class="meta-cell">
             <span>Format</span>
             <p><FileType2 :size="13" /> {{ previewType }}</p>
+          </div>
+        </div>
+
+        <!-- ── Editable metadata form ── -->
+        <div v-else class="meta-edit-form">
+          <div class="edit-field">
+            <label class="edit-label" for="edit-created">Created</label>
+            <input id="edit-created" v-model="editFields.created" class="edit-input" type="date" />
+          </div>
+          <div class="edit-field">
+            <label class="edit-label" for="edit-size">File Size</label>
+            <input id="edit-size" v-model="editFields.size" class="edit-input" type="text" placeholder="e.g. 2.4 MB" />
+          </div>
+          <div class="edit-field">
+            <label class="edit-label" for="edit-type">Format</label>
+            <input id="edit-type" v-model="editFields.type" class="edit-input" type="text" placeholder="e.g. PDF Document" />
+          </div>
+ 
+          <!-- Save / Cancel actions -->
+          <div class="edit-actions">
+            <button class="action-btn cancel-btn" type="button" :disabled="isSaving" @click="cancelEditing">
+              <XCircle :size="15" />
+              Cancel
+            </button>
+            <button class="action-btn save-btn" type="button" :disabled="isSaving" @click="saveMetadata">
+              <Save :size="15" />
+              {{ isSaving ? 'Saving…' : 'Save' }}
+            </button>
           </div>
         </div>
       </section>
@@ -147,6 +286,7 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
   padding: 1rem;
   overflow: auto;
   flex: 1;
+  position: relative;
 }
 
 .preview-title {
@@ -178,6 +318,14 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
   font-weight: 700;
   display: inline-flex;
   align-items: center;
+  margin : 0;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
 }
 
 /* QUICK FIX: This should be a button, but we can iterate later */
@@ -252,5 +400,147 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
 .open-file-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+.edit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+ 
+.edit-btn:hover {
+  border-color: #7c3aed;
+  color: #7c3aed;
+  background: #faf5ff;
+}
+ 
+.meta-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+ 
+.edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+ 
+.edit-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+ 
+.edit-input {
+  border: 1px solid #d8dee7;
+  border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.88rem;
+  color: #1e293b;
+  background: #ffffff;
+  outline: none;
+  font-family: inherit;
+}
+ 
+.edit-input:focus {
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.12);
+}
+ 
+.edit-title {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+ 
+.edit-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+ 
+.action-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+ 
+.cancel-btn {
+  border: 1px solid #d8dee7;
+  background: #f8fafc;
+  color: #475569;
+}
+ 
+.cancel-btn:hover:not(:disabled) {
+  background: #f1f5f9;
+  border-color: #94a3b8;
+}
+ 
+.save-btn {
+  border: none;
+  background: linear-gradient(135deg, #5b21b6 0%, #7c3aed 100%);
+  color: #ffffff;
+}
+ 
+.save-btn:hover:not(:disabled) {
+  opacity: 0.92;
+}
+ 
+.action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+ 
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+ 
+.toast-success {
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+}
+ 
+.toast-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+ 
+.toast-fade-enter-active,
+.toast-fade-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+ 
+.toast-fade-enter-from,
+.toast-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
 }
 </style>


### PR DESCRIPTION
# Add metadata editing to preview drawer for authorized users #163 
## Changes :
* Edit button

* Make metadata fields editable for authorized users

* Save and cancle buttons

* Display some kind of confirmation after succesful or unsuccesful update

* Form resets on cancel or document switch