### PR TITLE
Feature/frontend/summary

### DIFF
--- a/src/front_end/README.md
+++ b/src/front_end/README.md
@@ -66,15 +66,12 @@ The only way to access the DMS now is through logging in.
 Any attempt to bypass the path by adding /search would result in being redirected to the / path.
 1. ```http://localhost:8080``` / ```http://localhost:5173```
 2. Rress login
-3. Enter credentials
-   > frontend_tester
-
-   > password
+3. Enter credentials for an ordinary user or admin
 5. Access to DMS
 ________________________________________
 
 # Keycloak
-To access keycloak you can go to: ```https://Keycloak```
+To access keycloak you can go to the keycloak site. 
 
 Log in as admin
 

--- a/src/front_end/README.md
+++ b/src/front_end/README.md
@@ -74,9 +74,9 @@ Any attempt to bypass the path by adding /search would result in being redirecte
 ________________________________________
 
 # Keycloak
-To access keycloak you can go to: ```https://ad.dms-lookup.com:8443/```
-## Create a user
-Use the admin credentials to log in (*admin, pass*).
+To access keycloak you can go to: ```https://Keycloak```
+
+Log in as admin
 
 Choose User from the left side bar.
 
@@ -96,21 +96,15 @@ Choose User from the left side bar.
 5. **Save password**
 ________________________________________
 
-### Test account
-**username:** frontend_tester
-**password:** password
-
-________________________________________
-
 # Environment Setup
 Before running the service, you must create a `.env` file in the /front_end/ directory.
 
 Create `.env` file following this structure:
 
 ```
-KEYCLOAK_BASE_URL=https://ad.dms-lookup.com:8443
+KEYCLOAK_BASE_URL= Keycloak Base URL
 KEYCLOAK_REALM=master
-KEYCLOAK_CLIENT_ID=dms-frontend
-API_BASE_URL=/api
-API_HOST=http://dmis-api.dev.dms-lookup.com:8000/
+KEYCLOAK_CLIENT_ID=Keyloak Client ID
+API_BASE_URL=/api/
+API_HOST= The develop API URL for frontend
 ```

--- a/src/front_end/README.md
+++ b/src/front_end/README.md
@@ -104,7 +104,7 @@ Create `.env` file following this structure:
 ```
 KEYCLOAK_BASE_URL= Keycloak Base URL
 KEYCLOAK_REALM=master
-KEYCLOAK_CLIENT_ID=Keyloak Client ID
+KEYCLOAK_CLIENT_ID= Keyloak Client ID
 API_BASE_URL=/api/
 API_HOST= The develop API URL for frontend
 ```

--- a/src/front_end/index.html
+++ b/src/front_end/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/front_end/src/components/SearchFiltersCard.vue
+++ b/src/front_end/src/components/SearchFiltersCard.vue
@@ -2,44 +2,64 @@
 import { computed, ref } from 'vue'
 import { Grid2X2, FileText, Shield } from 'lucide-vue-next'
 
+// Will eventually fetch these filter options from the backend or something??
 const sourceFilters = ['GitHub', 'GitLab', 'Network File System'] // Add more sources needed if possible
 const typeFilters = ['PDF (.pdf)', 'Word (.docx)', 'Excel (.xlsx)', 'Text / Markdown (.txt, .md)']
 const securityFilters = ['Public', 'Internal', 'Sensitive', 'Confidential']
 
-const selectedFilters = ref({
-  source: [],
-  type: [],
-  security: []
+const props = defineProps({
+  selectedFilters: Object
 })
+const emit = defineEmits(['update:filters'])
 
-const hasActiveFilters = computed(() => {
-  return (
-    selectedFilters.value.source.length > 0 || selectedFilters.value.type.length > 0 || selectedFilters.value.security.length > 0
-  )
-})
+/* Local refs for filter selection */
+const localSource = ref([...props.selectedFilters.source])
+const localType = ref([...props.selectedFilters.type])
+const localSecurity = ref([...props.selectedFilters.security])
 
+/* Computed to check if any filters are active */
+const hasActiveFilters = computed(
+  () => localSource.value.length > 0 || localType.value.length > 0 || localSecurity.value.length > 0
+)
+
+/* Check if a filter is selected */
 const isSelected = (filterType, value) => {
-  return selectedFilters.value[filterType].includes(value)
+  if (filterType === 'source') return localSource.value.includes(value)
+  if (filterType === 'type') return localType.value.includes(value)
+  if (filterType === 'security') return localSecurity.value.includes(value)
+  return false
 }
 
-// Placeholder for handling filter changes.
-// In a later implementation, this will probably update the search query or trigger a new search with the applied filters.
-const handleFilterChange = (filterType, value) => {
-  if (isSelected(filterType, value)) {
-    selectedFilters.value[filterType] = selectedFilters.value[filterType].filter((item) => item !== value)
+/* Toggle filter selection */
+const toggleFilter = (filterType, value) => {
+  let refArray
+  if (filterType === 'source') refArray = localSource
+  else if (filterType === 'type') refArray = localType
+  else if (filterType === 'security') refArray = localSecurity
+  else return
+
+  if (refArray.value.includes(value)) {
+    refArray.value = refArray.value.filter((f) => f !== value)
   } else {
-    selectedFilters.value[filterType] = [...selectedFilters.value[filterType], value]
+    refArray.value = [...refArray.value, value]
   }
-
-  console.log(`Selected ${filterType} filters:`, selectedFilters.value[filterType])
+  emit('update:filters', {
+    source: localSource.value,
+    type: localType.value,
+    security: localSecurity.value
+  })
 }
 
+/* Clear all filters */
 const clearAllFilters = () => {
-  selectedFilters.value = {
+  localSource.value = []
+  localType.value = []
+  localSecurity.value = []
+  emit('update:filters', {
     source: [],
     type: [],
     security: []
-  }
+  })
 }
 </script>
 
@@ -50,6 +70,7 @@ their search queries.
 <template>
   <div class="filters-card">
     <div class="filters-row">
+      <!-- Source Filters -->
       <div class="filter-group">
         <span class="group-label">
           <Grid2X2 :size="14" />
@@ -59,9 +80,7 @@ their search queries.
           v-for="item in sourceFilters"
           :key="item"
           :class="['chip', { active: isSelected('source', item) }]"
-          type="button"
-          :aria-pressed="isSelected('source', item)"
-          @click="handleFilterChange('source', item)"
+          @click="toggleFilter('source', item)"
         >
           {{ item }}
         </button>
@@ -69,6 +88,7 @@ their search queries.
 
       <span class="group-divider" aria-hidden="true"></span>
 
+      <!-- Type Filters -->
       <div class="filter-group">
         <span class="group-label">
           <FileText :size="14" />
@@ -78,9 +98,7 @@ their search queries.
           v-for="item in typeFilters"
           :key="item"
           :class="['chip', { active: isSelected('type', item) }]"
-          type="button"
-          :aria-pressed="isSelected('type', item)"
-          @click="handleFilterChange('type', item)"
+          @click="toggleFilter('type', item)"
         >
           {{ item }}
         </button>
@@ -88,6 +106,7 @@ their search queries.
 
       <span class="group-divider" aria-hidden="true"></span>
 
+      <!-- Security Filters -->
       <div class="filter-group">
         <span class="group-label">
           <Shield :size="14" />
@@ -97,15 +116,13 @@ their search queries.
           v-for="item in securityFilters"
           :key="item"
           :class="['chip', { active: isSelected('security', item) }]"
-          type="button"
-          :aria-pressed="isSelected('security', item)"
-          @click="handleFilterChange('security', item)"
+          @click="toggleFilter('security', item)"
         >
           {{ item }}
         </button>
       </div>
       <div class="filters-header">
-        <button v-if="hasActiveFilters" class="clear-button" type="button" @click="clearAllFilters">Clear all</button>
+        <button v-if="hasActiveFilters" class="clear-button" @click="clearAllFilters">Clear all</button>
       </div>
     </div>
   </div>
@@ -127,22 +144,14 @@ their search queries.
   margin-left: auto;
 }
 
-.filters-title {
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  color: #99a4b8;
-  text-transform: uppercase;
-}
-
 .clear-button {
   border: none;
   background: transparent;
   color: #7c3aed;
-  font-size: 0.85rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  padding: 0.1rem 0.2rem;
+  padding: 0.1rem 0.6rem;
 }
 
 .clear-button:hover {

--- a/src/front_end/src/components/SearchMatches.vue
+++ b/src/front_end/src/components/SearchMatches.vue
@@ -112,10 +112,10 @@ const resultsLabel = computed(() => {
 }
 
 .result-main {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 0.8rem;
-  align-items: start;
 }
 
 .result-content {

--- a/src/front_end/src/components/SearchPreviewDrawer.vue
+++ b/src/front_end/src/components/SearchPreviewDrawer.vue
@@ -10,6 +10,7 @@
 
 import { X, StarsIcon, CalendarDays, HardDrive, FileType2, ExternalLink } from 'lucide-vue-next'
 import { useSearchMetadata } from '@/composables/useSearchMetadata'
+import { useAISummary } from '@/composables/aiSummary'
 
 /* Props received from parent component (SearchView) */
 const props = defineProps({
@@ -24,6 +25,9 @@ const emit = defineEmits(['close'])
 
 /* Use custom composable to extract metadata for the selected file */
 const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } = useSearchMetadata(props)
+
+/* AI summary composable */
+const { aiSummaryHtml, summaryError, isGeneratingSummary, generateAISummary } = useAISummary(props)
 </script>
 
 <template>
@@ -47,15 +51,6 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
         <span class="tag">{{ previewType }}</span>
       </div>
 
-      <!-- AI Summary section -->
-      <section class="panel-section">
-        <!-- QUICK FIX: This should be a button, where we ask for the ai summary for chosen file -->
-        <p class="section-title">AI SUMMARY</p>
-        <div class="generate-summary">
-          <p class="summary-card"><StarsIcon :size="13" />Generate AI summary</p>
-        </div>
-      </section>
-
       <!-- Technical Metadata section -->
       <section class="panel-section">
         <p class="section-title">TECHNICAL METADATA</p>
@@ -73,6 +68,27 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
             <p><FileType2 :size="13" /> {{ previewType }}</p>
           </div>
         </div>
+      </section>
+
+      <!-- AI Summary section -->
+      <section class="panel-section">
+        <p class="section-title">AI SUMMARY</p>
+        <div v-if="aiSummaryHtml" class="meta-cell meta-cell-summary">
+          <div class="summary-markdown" v-html="aiSummaryHtml"></div>
+        </div>
+        <button
+          v-else
+          class="meta-cell meta-cell-summary summary-cell-button"
+          type="button"
+          :disabled="isGeneratingSummary"
+          @click="generateAISummary"
+        >
+          <p>
+            <StarsIcon :size="13" />
+            {{ isGeneratingSummary ? 'Generating summary...' : 'Generate AI Summary' }}
+          </p>
+          <p v-if="summaryError" class="error">Error generating summary: {{ summaryError }}</p>
+        </button>
       </section>
     </div>
 
@@ -102,7 +118,7 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
   top: 0;
   right: 0;
   height: 100vh;
-  width: min(520px, 92vw);
+  width: min(700px, 100vw);
   background: #ffffff;
   transform: translateX(100%);
   transition: transform 0.25s ease;
@@ -180,21 +196,6 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
   align-items: center;
 }
 
-/* QUICK FIX: This should be a button, but we can iterate later */
-.summary-card {
-  border: 1px solid #e2e8f0;
-  background: #f8faff;
-  border-radius: 12px;
-  padding: 0.75rem;
-  color: #334155;
-  margin: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.32rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
 .meta-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -222,6 +223,33 @@ const { previewTitle, previewType, previewCreatedAt, previewSize, previewLink } 
   gap: 0.32rem;
   font-size: 0.82rem;
   font-weight: 600;
+}
+
+.meta-cell-summary {
+  grid-column: 1 / -1;
+  overflow: hidden;
+}
+
+.summary-markdown {
+  padding: 1rem 1.5rem;
+}
+
+.summary-cell-button {
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  appearance: none;
+  cursor: pointer;
+}
+
+.summary-cell-button:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: #f1f5f9;
+}
+
+.summary-cell-button:disabled {
+  opacity: 0.8;
+  cursor: wait;
 }
 
 .preview-footer {

--- a/src/front_end/src/composables/aiSummary.js
+++ b/src/front_end/src/composables/aiSummary.js
@@ -1,0 +1,73 @@
+import { computed, ref } from 'vue'
+import { useSearchMetadata } from '@/composables/useSearchMetadata'
+
+export function useAISummary(props) {
+  /* Unique pointer from metadata */
+  const { uniquePointer } = useSearchMetadata(props)
+
+  const API_BASE_URL = import.meta.env.API_BASE_URL.replace(/\/$/, '')
+
+  /* Summary state */
+  const aiSummary = ref('')
+  const aiSummaryHtmlRaw = ref('')
+  const summaryPointer = ref('')
+  const summaryError = ref('')
+  const isGeneratingSummary = ref(false)
+
+  /* Summary for specific file and disappears when new file is selected */
+  const aiSummaryHtml = computed(() => (summaryPointer.value === uniquePointer.value ? aiSummaryHtmlRaw.value : ''))
+
+  /* When clicking button Generate AI summary */
+  const generateAISummary = async () => {
+    if (!uniquePointer.value) {
+      aiSummary.value = ''
+      aiSummaryHtmlRaw.value = ''
+      summaryPointer.value = ''
+      summaryError.value = ''
+      return
+    }
+
+    isGeneratingSummary.value = true
+    summaryError.value = ''
+    aiSummary.value = ''
+    aiSummaryHtmlRaw.value = ''
+    summaryPointer.value = ''
+
+    try {
+      const response = await globalThis.fetch(`${API_BASE_URL}/summary`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_pointer: uniquePointer.value })
+      })
+
+      if (!response.ok) {
+        throw new Error(`Summary request failed (${response.status})`)
+      }
+
+      const contentType = response.headers.get('content-type') || ''
+      let summaryText = ''
+
+      if (contentType.includes('application/json')) {
+        const data = await response.json()
+        summaryText = typeof data.summary === 'string' ? data.summary : JSON.stringify(data)
+      } else {
+        summaryText = await response.text()
+      }
+
+      aiSummary.value = summaryText
+      aiSummaryHtmlRaw.value = globalThis.marked ? globalThis.marked.parse(summaryText) : summaryText
+      summaryPointer.value = uniquePointer.value
+    } catch (error) {
+      summaryError.value = error.message
+    } finally {
+      isGeneratingSummary.value = false
+    }
+  }
+
+  return {
+    aiSummaryHtml,
+    summaryError,
+    isGeneratingSummary,
+    generateAISummary
+  }
+}

--- a/src/front_end/src/composables/useSearchMetadata.js
+++ b/src/front_end/src/composables/useSearchMetadata.js
@@ -53,6 +53,12 @@ const resolveLink = (entry) => {
   return pick(metadata?.clickable_url, entry?.clickable_url)
 }
 
+const resolveUniquePointer = (entry) => {
+  const metadata = getMetadata(entry)
+
+  return pick(metadata?.unique_pointer, entry?.unique_pointer)
+}
+
 /* Function to resolve the document type from source type and name. */
 export const TYPE_KEYWORDS = {
   'PDF Document': ['.pdf'],
@@ -139,6 +145,8 @@ export const useSearchMetadata = (props) => {
 
   const previewLink = computed(() => resolveLink(props.selectedMatch))
 
+  const uniquePointer = computed(() => resolveUniquePointer(props.selectedMatch))
+
   const normalizeMatches = (matches = []) =>
     matches.map((entry, index) => {
       const metadata = getMetadata(entry)
@@ -168,6 +176,7 @@ export const useSearchMetadata = (props) => {
     previewCreatedAt,
     previewSize,
     previewLink,
+    uniquePointer,
     normalizeMatches,
     resolveMatchDate,
     resolveSource

--- a/src/front_end/src/composables/useSearchMetadata.js
+++ b/src/front_end/src/composables/useSearchMetadata.js
@@ -54,16 +54,24 @@ const resolveLink = (entry) => {
 }
 
 /* Function to resolve the document type from source type and name. */
-const TYPE_KEYWORDS = {
-  'PDF Document': ['pdf'],
-  'Word Document': ['word', 'doc', 'docx'],
-  'Excel Spreadsheet': ['excel', 'sheet', 'xlsx'],
-  'Text Document': ['txt'],
-  'Markdown Document': ['markdown', 'md']
+export const TYPE_KEYWORDS = {
+  'PDF Document': ['.pdf'],
+  'Word Document': ['word', 'doc', '.docx'],
+  'Excel Spreadsheet': ['excel', 'sheet', '.xlsx'],
+  'Text Document': ['.txt'],
+  'Markdown Document': ['markdown', '.md']
+}
+
+/* Used for filtering doc types (SearchView, SearchFilterCard)*/
+export const TYPE_FILTERS = {
+  'PDF (.pdf)': ['.pdf'],
+  'Word (.docx)': ['.doc', '.docx', 'word'],
+  'Excel (.xlsx)': ['.xlsx'],
+  'Text / Markdown (.txt, .md)': ['.md', '.txt']
 }
 
 /* Function to resolve the document type from source type and name. */
-const resolveDocumentType = ({ sourceType, sourceName }) => {
+export const resolveDocumentType = ({ sourceType, sourceName }) => {
   const type = String(sourceType || '').toLowerCase()
   const name = String(sourceName || '').toLowerCase()
   const typeOrName = `${type} ${name}`

--- a/src/front_end/src/views/SearchView.vue
+++ b/src/front_end/src/views/SearchView.vue
@@ -107,7 +107,7 @@ const handleFilterChange = (filters) => {
   }
   matches.value = allMatches.value.filter((match) => {
     const filename = (match.filename || match.name || '').toLowerCase()
-    const securityClass = resolveSecurityClass(match).toLowerCase()
+    // const securityClass = resolveSecurityClass(match).toLowerCase()
     // const source = (match.source || '').toLowerCase()
 
     // TYPE FILTER
@@ -129,12 +129,12 @@ const handleFilterChange = (filters) => {
     // const sourceMatch = filters.source.length === 0 || filters.source.some((s) => source.includes(s.toLowerCase()))
 
     // SECURITY FILTER
-    const securityMatch =
-      filters.security.length === 0 || filters.security.some((selected) => securityClass === selected.toLowerCase())
+    // const securityMatch =
+    //  filters.security.length === 0 || filters.security.some((selected) => securityClass === selected.toLowerCase())
 
     // add sourceMatch and secuirtyMatch later
     // return typeMatch && sourceMatch && secuirtyMatch
-    return typeMatch && securityMatch
+    return typeMatch //&& securityMatch
   })
 }
 </script>

--- a/src/front_end/src/views/SearchView.vue
+++ b/src/front_end/src/views/SearchView.vue
@@ -16,10 +16,11 @@ import SearchBar from '@/components/SearchBar.vue'
 import SearchFiltersCard from '@/components/SearchFiltersCard.vue'
 import SearchMatches from '@/components/SearchMatches.vue'
 import SearchPreviewDrawer from '@/components/SearchPreviewDrawer.vue'
-import { resolveFilename } from '@/composables/useSearchMetadata'
+import { resolveFilename, TYPE_FILTERS } from '@/composables/useSearchMetadata'
 
 /* Reactive state variables for search results and UI state */
 const matches = ref([])
+const allMatches = ref([])
 const selectedFile = ref('')
 const selectedMatch = ref(null)
 const error = ref('')
@@ -29,6 +30,13 @@ const isPreviewOpen = ref(false)
 
 /* Base URL for API requests, configurable via environment variable */
 const API_BASE_URL = import.meta.env.API_BASE_URL.replace(/\/$/, '')
+
+/* Filters so it can access matches */
+const selectedFilters = ref({
+  source: [],
+  type: [],
+  security: []
+})
 
 /* Performs a search when the SearchBar emits a search event */
 const handleSearch = async (query) => {
@@ -56,7 +64,10 @@ const handleSearch = async (query) => {
 
     const data = await res.json()
     console.log('Search response:', data)
-    matches.value = Array.isArray(data) ? data : data.results || data.matches || []
+    const resultArray = Array.isArray(data) ? data : data.results || data.matches || []
+
+    allMatches.value = resultArray
+    matches.value = resultArray
 
     if (matches.value.length === 0) {
       error.value = 'No matching files found.'
@@ -84,9 +95,47 @@ const closePreview = () => {
   isPreviewOpen.value = false
 }
 
-/* Handle changes to search filters (currently just logs the change) */
-const handleFilterChange = (filter) => {
-  console.log('Filter changed:', filter)
+/* Handle changes to search filters  */
+// TODO: add source & security filtering.
+const handleFilterChange = (filters) => {
+  selectedFilters.value = filters
+  console.log('Filter changed:', filters)
+  // If no filters → show everything
+  if (filters.source.length === 0 && filters.type.length === 0 && filters.security.length === 0) {
+    matches.value = allMatches.value
+    return
+  }
+  matches.value = allMatches.value.filter((match) => {
+    const filename = (match.filename || match.name || '').toLowerCase()
+    const securityClass = resolveSecurityClass(match).toLowerCase()
+    // const source = (match.source || '').toLowerCase()
+
+    // TYPE FILTER
+    const typeMatch =
+      filters.type.length === 0 ||
+      filters.type.some((filterLabel) => {
+        // Find the TYPE_KEYWORDS entry that matches the selected filter
+        const keywordsEntry = Object.entries(TYPE_FILTERS).find(([docType]) => docType === filterLabel)
+
+        if (!keywordsEntry) return false
+
+        const [, keywords] = keywordsEntry
+
+        // Only match filename against the keywords for this filter
+        return keywords.some((kw) => filename.endsWith(kw))
+      })
+
+    // SOURCE FILTER
+    // const sourceMatch = filters.source.length === 0 || filters.source.some((s) => source.includes(s.toLowerCase()))
+
+    // SECURITY FILTER
+    const securityMatch =
+      filters.security.length === 0 || filters.security.some((selected) => securityClass === selected.toLowerCase())
+
+    // add sourceMatch and secuirtyMatch later
+    // return typeMatch && sourceMatch && secuirtyMatch
+    return typeMatch && securityMatch
+  })
 }
 </script>
 
@@ -97,7 +146,7 @@ const handleFilterChange = (filter) => {
     <SearchBar :loading="isSearching" @search="handleSearch" />
 
     <!-- Search Filters Component -->
-    <SearchFiltersCard @filter-change="handleFilterChange" />
+    <SearchFiltersCard :selectedFilters="selectedFilters" @update:filters="handleFilterChange" />
 
     <!-- Search Matches Component -->
     <SearchMatches :matches="matches" :loading="isSearching" :selected="selectedFile" :query="lastQuery" @select="selectMatch" />


### PR DESCRIPTION
**Frontend: Summary for single file**

#241 Summary Fetching
#253 Single file summary fetching
#142 Add visualization for summary for signle document
#157 Implement filters (logic only, will be improved)

New branch for things that were in the old one so now everything is seperated from api brances. 
This is for single summary. Users click on button, AI summary is generated and then displayed for the user.

<img width="758" height="269" alt="generate" src="https://github.com/user-attachments/assets/135bc841-f407-4ba8-b297-750ad8146c16" />

<img width="759" height="360" alt="generating" src="https://github.com/user-attachments/assets/d108f874-182b-4a22-8d86-098a6804638a" />

<img width="754" height="962" alt="summary1" src="https://github.com/user-attachments/assets/ea3df14e-d92b-4d38-8e92-6556764d5c02" />
