### PR TITLE
ref #162 Handle missing metadata since they can differ for sources and formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "@vue/test-utils": "^2.4.10",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.5"
+  }
+}

--- a/src/front_end/package.json
+++ b/src/front_end/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
   },
   "dependencies": {
     "lucide-vue-next": "^0.574.0",

--- a/src/front_end/package.json
+++ b/src/front_end/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "vitest",
+    "test": "vitest run --reporter=dot",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/src/front_end/src/components/SearchMatches.vue
+++ b/src/front_end/src/components/SearchMatches.vue
@@ -98,12 +98,19 @@ const resolveBadgeClass = (match) => {
               <div class="meta-row">
                 <span><FileText :size="13" /> {{ resolveDocumentType(item.rawMatch) }}</span>
                 <span><Calendar :size="13" /> {{ resolveDateOnly(item.rawMatch) }}</span>
-                <span
-                  ><ExternalLink :size="13" />
-                  <a :href="resolveLink(item.rawMatch)" target="_blank" rel="noopener noreferrer" @click.stop>{{
-                    resolveSource(item.rawMatch)
-                  }}</a></span
-                >
+                <span>
+                  <template v-if="resolveLink(item.rawMatch)">
+                    <ExternalLink :size="13" />
+                    <a :href="resolveLink(item.rawMatch)" target="_blank" rel="noopener noreferrer" @click.stop>{{
+                      resolveSource(item.rawMatch)
+                    }}</a>
+                  </template>
+                  <template v-else>
+                    <span class="only-source">
+                      {{ resolveSource(item.rawMatch) }}
+                    </span>
+                  </template>
+                </span>
               </div>
             </div>
             <span class="security-badge" :class="resolveBadgeClass(item.rawMatch)">{{ resolveBadgeText(item.rawMatch) }}</span>
@@ -189,6 +196,10 @@ const resolveBadgeClass = (match) => {
   gap: 0.75rem;
   color: #9aa7bb;
   font-size: 0.84rem;
+}
+
+.only-source {
+  color: #9aa7bb;
 }
 
 .meta-row span {

--- a/src/front_end/src/composables/useSearchMetadata.js
+++ b/src/front_end/src/composables/useSearchMetadata.js
@@ -13,16 +13,12 @@ const pick = (...values) => {
 }
 
 /* Function to extract metadata from an entry. */
-const getMetadata = (entry) => {
-  if (!entry || typeof entry !== 'object') {
+export const getMetadata = (entry) => {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
     return {}
   }
 
-  if (entry.metadata && typeof entry.metadata === 'object') {
-    return entry.metadata
-  }
-
-  return entry
+  return entry.metadata && typeof entry.metadata === 'object' && !Array.isArray(entry.metadata) ? entry.metadata : entry
 }
 
 /* Function to resolve the filename from metadata or entry. Can differ between sources. */
@@ -35,20 +31,20 @@ export const resolveFilename = (entry, index = 0) => {
 export const resolveDocumentType = (entry) => {
   const metadata = getMetadata(entry)
 
-  return pick(metadata?.file_type_description, entry?.file_type_description)
+  return pick(metadata?.file_type_description, entry?.file_type_description, 'Unknown')
 }
 
 export const resolveDocumentExtension = (entry) => {
   const metadata = getMetadata(entry)
 
-  return pick(metadata?.file_type, entry?.file_type)
+  return pick(metadata?.file_type, entry?.file_type, 'Unknown')
 }
 
 /* Function to resolve the source of the document from metadata. */
 export const resolveSource = (entry) => {
   const metadata = getMetadata(entry)
 
-  return pick(metadata?.source_system, entry?.source_system)
+  return pick(metadata?.source_system, entry?.source_system, 'Unknown')
 }
 
 /* Function to resolve the date from a value. */
@@ -56,7 +52,11 @@ export const resolveDateOnly = (entry) => {
   const metadata = getMetadata(entry)
   const value = pick(metadata?.last_edit_date, entry?.last_edit_date)
 
-  return pick((value || '').split('T')[0])
+  if (!value || typeof value !== 'string') {
+    return 'Unknown date'
+  }
+
+  return value.includes('T') ? value.split('T')[0] : value
 }
 
 /* Function to resolve the clickable link from metadata or entry. */
@@ -69,7 +69,7 @@ export const resolveLink = (entry) => {
 export const resolveSecurityClass = (entry) => {
   const metadata = getMetadata(entry)
 
-  return pick(metadata?.security_class, entry?.security_class)
+  return pick(metadata?.security_class, entry?.security_class, 'Pending')
 }
 
 /**

--- a/src/front_end/src/test/useSearchMetadata.test.js
+++ b/src/front_end/src/test/useSearchMetadata.test.js
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'vitest'
+import {
+  getMetadata,
+  resolveDocumentExtension,
+  resolveFilename,
+  resolveDocumentType,
+  resolveDateOnly,
+  resolveSource,
+  resolveLink,
+  resolveSecurityClass
+} from '@/composables/useSearchMetadata'
+
+/* Test for valid metadata extraction */
+describe('useSearchMetadata', () => {
+  /* Unique pointer resolution */
+  test('returns unique pointer from metadata', () => {
+    const entry = {
+      metadata: {
+        unique_pointer: 'pointer-123'
+      }
+    }
+
+    expect(getMetadata(entry)).toEqual({ unique_pointer: 'pointer-123' })
+  })
+
+  test('falls back to entry unique pointer', () => {
+    const entry = {
+      unique_pointer: 'entry-pointer-456'
+    }
+
+    expect(getMetadata(entry)).toEqual({ unique_pointer: 'entry-pointer-456' })
+  })
+
+  test('returns empty object for no entry', () => {
+    const entry = {}
+
+    expect(getMetadata(entry)).toEqual({})
+  })
+
+  /* Filename resolution */
+  test('uses metadata name when available', () => {
+    const entry = {
+      metadata: {
+        name: 'report.pdf'
+      }
+    }
+
+    expect(resolveFilename(entry)).toBe('report.pdf')
+  })
+
+  test('falls back to entry name', () => {
+    const entry = {
+      name: 'fallback.pdf'
+    }
+
+    expect(resolveFilename(entry)).toBe('fallback.pdf')
+  })
+
+  test('returns generated fallback when no name exists', () => {
+    const entry = {}
+
+    expect(resolveFilename(entry, 2)).toBe('result-3')
+  })
+
+  test('handles missing metadata safely', () => {
+    expect(resolveFilename(null)).toBe('result-1')
+  })
+
+  /* Document type resolution */
+  test('returns Unknown when document type is missing', () => {
+    expect(resolveDocumentType({})).toBe('Unknown')
+  })
+
+  /* Document extension resolution */
+  test('returns Unknown when document extension is missing', () => {
+    expect(resolveDocumentExtension({})).toBe('Unknown')
+  })
+
+  /* Source system resolution */
+  test('returns Unknown when source system is missing', () => {
+    const entry = {}
+    expect(resolveSource(entry)).toBe('Unknown')
+  })
+
+  /* Date resolution */
+  test('extracts date correctly', () => {
+    const entry = {
+      metadata: {
+        last_edit_date: '2026-05-07T10:30:00'
+      }
+    }
+
+    expect(resolveDateOnly(entry)).toBe('2026-05-07')
+  })
+
+  test('handles invalid dates safely', () => {
+    const entry = {
+      metadata: {
+        last_edit_date: null
+      }
+    }
+
+    expect(resolveDateOnly(entry)).toBe('Unknown date')
+  })
+
+  /* Clickble link resolution */
+  test('returns nothing when clickable url is missing', () => {
+    const entry = {}
+    expect(resolveLink(entry)).toBe('')
+  })
+
+  /* Security classification resolution */
+  test('returns Pending when security classifications is pending', () => {
+    const entry = {}
+    expect(resolveSecurityClass(entry)).toBe('Pending')
+  })
+})

--- a/src/front_end/src/test/useSearchMetadata.test.js
+++ b/src/front_end/src/test/useSearchMetadata.test.js
@@ -10,25 +10,25 @@ import {
   resolveSecurityClass
 } from '@/composables/useSearchMetadata'
 
-/* Test for valid metadata extraction */
+/* Test valid metadata extraction */
 describe('useSearchMetadata', () => {
   /* Unique pointer resolution */
   test('returns unique pointer from metadata', () => {
     const entry = {
       metadata: {
-        unique_pointer: 'pointer-123'
+        unique_pointer: 'pointer-1'
       }
     }
 
-    expect(getMetadata(entry)).toEqual({ unique_pointer: 'pointer-123' })
+    expect(getMetadata(entry)).toEqual({ unique_pointer: 'pointer-1' })
   })
 
   test('falls back to entry unique pointer', () => {
     const entry = {
-      unique_pointer: 'entry-pointer-456'
+      unique_pointer: 'pointer-2'
     }
 
-    expect(getMetadata(entry)).toEqual({ unique_pointer: 'entry-pointer-456' })
+    expect(getMetadata(entry)).toEqual({ unique_pointer: 'pointer-2' })
   })
 
   test('returns empty object for no entry', () => {
@@ -41,11 +41,11 @@ describe('useSearchMetadata', () => {
   test('uses metadata name when available', () => {
     const entry = {
       metadata: {
-        name: 'report.pdf'
+        name: 'test.pdf'
       }
     }
 
-    expect(resolveFilename(entry)).toBe('report.pdf')
+    expect(resolveFilename(entry)).toBe('test.pdf')
   })
 
   test('falls back to entry name', () => {

--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,4 @@ change_dir = {toxinidir}/src/front_end
 commands = 
     npm install 
     npm run lint
+    npm test

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = false
 requires = 
     tox>=4
-envlist = pylint, ruffEnv, formatting_env, mypy-api, unittest_env, frontend_env
+envlist = pylint, ruffEnv, formatting_env, mypy-api, unittest_env, frontend_env, unittest_env_frontend
 
 [testenv]
 deps =
@@ -50,6 +50,12 @@ commands =
 allowlist_externals = npm
 change_dir = {toxinidir}/src/front_end
 commands = 
-    npm install 
+    npm install
     npm run lint
-    npm test
+
+[testenv:unittest_env_frontend]
+allowlist_externals = npm
+change_dir = {toxinidir}/src/front_end
+commands = 
+    npm install -D vitest
+    npm run test


### PR DESCRIPTION
Added so we hanlde mising metadata, I think all is there. Added some unit tests on the way too :)

in src/front_end/src/components/SearchMatches.vue i have made so you cant click on alink if there is no clickable link as for eg SMB, so it is just grey text

<img width="335" height="166" alt="image" src="https://github.com/user-attachments/assets/0b2d6bd6-d5d1-4909-94e3-f2aabcdeb451" />


