### PR TITLE
Feat/GitHub defined fields stream post

### DIFF
--- a/src/connectors/github/README.md
+++ b/src/connectors/github/README.md
@@ -60,6 +60,5 @@ that org, not by any additional permission.
 | `/defined_fields` | GET | Lists field keys returned for indexed documents (gateway union contract) |
 | `/index_needed_bool` | GET | Returns whether any repo has new content since the last index |
 | `/stream_files_to_index` | POST | Streams NDJSON — JSON body ``{"subdata": ...}``, then one file per line (same as GitLab) |
-| `/stream_files_to_index` | GET | **Deprecated** — use **POST** with JSON body instead |
 | `/get_files` | POST | Fetches specific files by pointer |
 | `/files_to_index` | GET | **Deprecated** — use `/stream_files_to_index` instead |

--- a/src/connectors/github/README.md
+++ b/src/connectors/github/README.md
@@ -57,7 +57,9 @@ that org, not by any additional permission.
 | `/auth_user` | GET | Redirects user to GitHub OAuth consent page (`callback-url` header required) |
 | `/callback` | GET | Exchanges GitHub authorization code for access/refresh tokens |
 | `/refresh_token` | GET | Refreshes an expiring access token (`refresh-token` header required) |
+| `/defined_fields` | GET | Lists field keys returned for indexed documents (gateway union contract) |
 | `/index_needed_bool` | GET | Returns whether any repo has new content since the last index |
-| `/stream_files_to_index` | GET | Streams NDJSON — subdata header followed by one file per line |
+| `/stream_files_to_index` | POST | Streams NDJSON — JSON body ``{"subdata": ...}``, then one file per line (same as GitLab) |
+| `/stream_files_to_index` | GET | **Deprecated** — use **POST** with JSON body instead |
 | `/get_files` | POST | Fetches specific files by pointer |
 | `/files_to_index` | GET | **Deprecated** — use `/stream_files_to_index` instead |

--- a/src/connectors/github/src/github_collector_api.py
+++ b/src/connectors/github/src/github_collector_api.py
@@ -44,7 +44,9 @@ class API:
         self.app.add_api_route("/index_needed_bool", self.index_needed_bool, methods=["GET"])
         self.app.add_api_route("/get_files", self.get_files, methods=["POST"])
         self.app.add_api_route("/files_to_index", self.files_to_index, methods=["GET"], deprecated=True)
-        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index, methods=["GET"])
+        self.app.add_api_route("/defined_fields", self.defined_fields_route, methods=["GET"])
+        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index_post, methods=["POST"])
+        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index_get, methods=["GET"], deprecated=True)
         self.app.add_api_route("/auth_user", self.auth_user, methods=["GET"])
         self.app.add_api_route("/callback", self.callback, methods=["GET"])
         self.app.add_api_route("/refresh_token", self.refresh_token, methods=["GET"])
@@ -97,13 +99,34 @@ class API:
         url = upload_file(content, "github_content.json")
         return {"subdata": content.get("subdata"), "file_url": url}
 
-    async def stream_files_to_index(
+    async def defined_fields_route(self) -> list[str]:
+        """Field keys compatible with gateway ``retrieve_defined_fields`` union (matches GitLab contract)."""
+        return list(self.github_instance.defined_fields.keys())
+
+    @staticmethod
+    def _strip_github_token(header: str | None) -> str | None:
+        return header.removeprefix("Bearer ").strip() if header else None
+
+    async def stream_files_to_index_post(
+        self,
+        body: dict[str, str | None] | None = None,
+        x_github_token: str | None = Header(default=None, alias="X-GitHub-Token"),
+    ) -> StreamingResponse:
+        """Stream NDJSON: subdata line then one JSON object per file — same POST + body shape as GitLab."""
+        subdata: str | None = body.get("subdata") if isinstance(body, dict) else None
+        token = self._strip_github_token(x_github_token)
+        return StreamingResponse(
+            self.github_instance.stream_files_to_index(subdata, token),
+            media_type="application/octet-stream",
+        )
+
+    async def stream_files_to_index_get(
         self,
         subdata: str | None = None,
         x_github_token: str | None = Header(default=None, alias="X-GitHub-Token"),
     ) -> StreamingResponse:
-        """Streaming endpoint for all files to index."""
-        token = x_github_token.removeprefix("Bearer ").strip() if x_github_token else None
+        """Use ``POST`` with JSON body ``{"subdata": ...}`` instead; retained for backwards compatibility."""
+        token = self._strip_github_token(x_github_token)
         return StreamingResponse(
             self.github_instance.stream_files_to_index(subdata, token),
             media_type="application/octet-stream",

--- a/src/connectors/github/src/github_collector_api.py
+++ b/src/connectors/github/src/github_collector_api.py
@@ -45,8 +45,7 @@ class API:
         self.app.add_api_route("/get_files", self.get_files, methods=["POST"])
         self.app.add_api_route("/files_to_index", self.files_to_index, methods=["GET"], deprecated=True)
         self.app.add_api_route("/defined_fields", self.defined_fields_route, methods=["GET"])
-        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index_post, methods=["POST"])
-        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index_get, methods=["GET"], deprecated=True)
+        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index, methods=["POST"])
         self.app.add_api_route("/auth_user", self.auth_user, methods=["GET"])
         self.app.add_api_route("/callback", self.callback, methods=["GET"])
         self.app.add_api_route("/refresh_token", self.refresh_token, methods=["GET"])
@@ -107,25 +106,13 @@ class API:
     def _strip_github_token(header: str | None) -> str | None:
         return header.removeprefix("Bearer ").strip() if header else None
 
-    async def stream_files_to_index_post(
+    async def stream_files_to_index(
         self,
         body: dict[str, str | None] | None = None,
         x_github_token: str | None = Header(default=None, alias="X-GitHub-Token"),
     ) -> StreamingResponse:
-        """Stream NDJSON: subdata line then one JSON object per file — same POST + body shape as GitLab."""
+        """Stream NDJSON: subdata line then one JSON object per file — POST + body shape as GitLab (``{"subdata": ...}``)."""
         subdata: str | None = body.get("subdata") if isinstance(body, dict) else None
-        token = self._strip_github_token(x_github_token)
-        return StreamingResponse(
-            self.github_instance.stream_files_to_index(subdata, token),
-            media_type="application/octet-stream",
-        )
-
-    async def stream_files_to_index_get(
-        self,
-        subdata: str | None = None,
-        x_github_token: str | None = Header(default=None, alias="X-GitHub-Token"),
-    ) -> StreamingResponse:
-        """Use ``POST`` with JSON body ``{"subdata": ...}`` instead; retained for backwards compatibility."""
         token = self._strip_github_token(x_github_token)
         return StreamingResponse(
             self.github_instance.stream_files_to_index(subdata, token),

--- a/src/connectors/github/src/interfacer_github.py
+++ b/src/connectors/github/src/interfacer_github.py
@@ -48,10 +48,10 @@ class GitHub:
         self._api_version = read_env_variable("CONGITHUB_GITHUB_API_VERSION")
         self._client = httpx.Client(timeout=REQUEST_TIMEOUT)
         file_type_resource = get_file_resource()
-        self.file_extensions = [extension.get("extension") for extension in file_type_resource]
-        self.extension_descriptions = {extension.get("extension"): extension.get("description") for extension in file_type_resource}
+        extensions = [extension.get("extension") for extension in file_type_resource]
+        descriptions = {extension.get("extension"): extension.get("description") for extension in file_type_resource}
         self.defined_fields = {"content": None, "name": None, "unique_pointer": None, "size": None, "source_system": None} | {
-            key: None for key in determine_file_type("", self.file_extensions, self.extension_descriptions)
+            key: None for key in determine_file_type("", extensions, descriptions)
         }
 
     def _get_repos(self, token: str | None = None) -> list:

--- a/src/connectors/github/src/interfacer_github.py
+++ b/src/connectors/github/src/interfacer_github.py
@@ -22,6 +22,7 @@ import httpx
 
 from shared_functions.variables import SOURCE_FILE
 from shared_functions.unpacker import unpack_values
+from shared_functions.file_type_logic import determine_file_type, get_file_resource
 from shared_functions.dmis_logger import dms_error, dms_info, dms_warning
 from shared_functions.initialisation_tools import read_env_variable
 
@@ -46,6 +47,12 @@ class GitHub:
         self.org = os.environ.get("CONGITHUB_GITHUB_ORG")
         self._api_version = read_env_variable("CONGITHUB_GITHUB_API_VERSION")
         self._client = httpx.Client(timeout=REQUEST_TIMEOUT)
+        file_type_resource = get_file_resource()
+        self.file_extensions = [extension.get("extension") for extension in file_type_resource]
+        self.extension_descriptions = {extension.get("extension"): extension.get("description") for extension in file_type_resource}
+        self.defined_fields = {"content": None, "name": None, "unique_pointer": None, "size": None, "source_system": None} | {
+            key: None for key in determine_file_type("", self.file_extensions, self.extension_descriptions)
+        }
 
     def _get_repos(self, token: str | None = None) -> list:
         """Retrieve all repositories the token can access (user or org)."""

--- a/src/connectors/github/src/interfacer_github.py
+++ b/src/connectors/github/src/interfacer_github.py
@@ -10,7 +10,6 @@ import base64
 import binascii
 import io
 import json
-import os
 import zipfile
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
@@ -44,7 +43,7 @@ class GitHub:
             raise ValueError("Missing CONGITHUB_GITHUB_API_URL")
         self.source_system = read_env_variable("CONGITHUB_GITHUB_SYSTEM_NAME")
         self.api_base = raw.rstrip("/") + "/"
-        self.org = os.environ.get("CONGITHUB_GITHUB_ORG")
+        self.org = read_env_variable("CONGITHUB_GITHUB_ORG", required=False)
         self._api_version = read_env_variable("CONGITHUB_GITHUB_API_VERSION")
         self._client = httpx.Client(timeout=REQUEST_TIMEOUT)
         file_type_resource = get_file_resource()
@@ -93,8 +92,8 @@ class GitHub:
 
     @staticmethod
     def _is_excluded_path(path: str) -> bool:
-        """Optional path filter via env GITHUB_EXCLUDE_PATHS (comma-separated tokens)."""
-        raw = os.environ.get("GITHUB_EXCLUDE_PATHS", "")
+        """Optional path filter via env CONGITHUB_GITHUB_EXCLUDE_PATHS (comma-separated tokens)."""
+        raw = read_env_variable("CONGITHUB_GITHUB_EXCLUDE_PATHS", required=False) or ""
         if not raw:
             return False
         path_l = path.lower()

--- a/src/connectors/github/test/test_core.py
+++ b/src/connectors/github/test/test_core.py
@@ -47,6 +47,13 @@ class TestGitHubHelpers(unittest.TestCase):
     def setUp(self) -> None:
         self.github = GitHub()
 
+    def test_defined_fields_matches_gitlab_contract_shape(self) -> None:
+        """Schema keys overlap GitLab connector (base fields + extensions from file_types)."""
+        keys = list(self.github.defined_fields.keys())
+        self.assertIn("content", keys)
+        self.assertIn("unique_pointer", keys)
+        self.assertIn("source_system", keys)
+
     def test_make_and_parse_pointer_roundtrip(self) -> None:
         """File pointer URL encodes and decodes to the same components."""
         pointer = self.github._make_file_pointer("owner/repo", "src/file.py", "main")


### PR DESCRIPTION
## Summary
Aligns the GitHub connector with how the **connector gateway** and **search engine** already call other connectors (notably GitLab): `GET /defined_fields` for field unions, and `POST /stream_files_to_index` with a JSON body containing `subdata`.
## Changes
- **`GET /defined_fields`** — Returns field keys from a `defined_fields` map built the same way as GitLab (`get_file_resource` / `determine_file_type`), so `ConnectorClient.retrieve_defined_fields` can include GitHub without broken or empty unions.
- **`POST /stream_files_to_index`** — Accepts JSON body `{"subdata": "<...>"}` plus `X-GitHub-Token`, matching `se_api/services/connector.py` streaming client and GitLab.
- **`GET /stream_files_to_index`** — Kept as **deprecated** (query `subdata`) for backwards compatibility.
- **Pylint:** `defined_fields` initialization uses local variables in `__init__` to stay under the `too-many-instance-attributes` limit (R0902)