### PR TITLE
feat(confluence): GET /defined_fields for gateway field union

### DIFF
--- a/src/connectors/confluence/README.md
+++ b/src/connectors/confluence/README.md
@@ -13,3 +13,11 @@ Authentication is per request. Callers should supply:
     X-Confluence-Token: <user API token>
 
 If headers are missing, endpoints return empty/no-op payloads and no Confluence API requests are made.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/get_files` | POST | Batch fetch pages by pointer |
+| `/stream_files_to_index` | POST | Stream NDJSON (subdata line + one page per line) |
+| `/defined_fields` | GET | Lists field keys returned for indexed pages (gateway union) |

--- a/src/connectors/confluence/src/confluence_service/collector_api.py
+++ b/src/connectors/confluence/src/confluence_service/collector_api.py
@@ -42,6 +42,7 @@ class API:
 
         self.app.add_api_route("/get_files", self.get_files, methods=["POST"])
         self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index, methods=["POST"])
+        self.app.add_api_route("/defined_fields", self.defined_fields_route, methods=["GET"])
 
     @asynccontextmanager
     async def lifespan(self, _: FastAPI) -> AsyncGenerator:
@@ -60,6 +61,10 @@ class API:
         if self.log_level == "debug":
             content = jsonable_encoder(errors)
         return JSONResponse(status_code=422, content=content)
+
+    async def defined_fields_route(self) -> list[str]:
+        """Field keys for gateway ``retrieve_defined_fields`` union (same pattern as GitLab)."""
+        return list(self.confluence_instance.defined_fields.keys())
 
     @staticmethod
     def _token(x_confluence_token: str | None) -> str | None:


### PR DESCRIPTION
Expose field keys from ConfluenceInterfacer.defined_fields; matches GitLab pattern for ConnectorClient.retrieve_defined_fields. README endpoint table.