### PR TITLE
Fixed so that we only send access_token during regular api calls, and…

### DIFF
--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -53,7 +53,6 @@ class AuthRoutes:
         key: str,
         value: str,
         max_age: int,
-        path: str = "/",
     ) -> None:
         """Set an HTTP-only authentication cookie on the response."""
         response.set_cookie(
@@ -63,7 +62,6 @@ class AuthRoutes:
             secure=True,
             samesite="none",
             max_age=max_age,
-            path=path,
         )
 
     def _set_auth_cookies(self, response: JSONResponse, token_data: dict[str, Any]) -> None:
@@ -75,9 +73,25 @@ class AuthRoutes:
         if isinstance(access_token, str):
             self._set_cookie(response, "access_token", access_token, self.ACCESS_COOKIE_MAX_AGE)
         if isinstance(refresh_token, str):
-            self._set_cookie(response, "refresh_token", refresh_token, self.REFRESH_COOKIE_MAX_AGE, path="/auth/refresh")
+            response.set_cookie(
+                key="refresh_token",
+                value=refresh_token,
+                httponly=True,
+                secure=True,
+                samesite=None,
+                max_age=self.REFRESH_COOKIE_MAX_AGE,
+                path="/auth/refresh",
+            )
         if isinstance(id_token, str):
-            self._set_cookie(response, "id_token", id_token, self.ACCESS_COOKIE_MAX_AGE, path="/auth/logout")
+            response.set_cookie(
+                key="id_token",
+                value=id_token,
+                httponly=True,
+                secure=True,
+                samesite="none",
+                max_age=self.ACCESS_COOKIE_MAX_AGE,
+                path="/auth/logout",
+            )
 
     async def _request_tokens(self, data: dict[str, str]) -> dict[str, Any]:
         """Request tokens from AD provider using provided form data."""

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -232,6 +232,6 @@ class AuthRoutes:
             content={"logout_url": logout_url},
         )
         response.delete_cookie("access_token", path="/", secure=True, samesite="none")
-        response.delete_cookie("refresh_token", path="/auth/refresh", secure=True, samesite="none")
-        response.delete_cookie("id_token", path="/auth/logout", secure=True, samesite="none")
+        response.delete_cookie("refresh_token", path="api/auth/refresh", secure=True, samesite="none")
+        response.delete_cookie("id_token", path="api/auth/logout", secure=True, samesite="none")
         return response

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -53,6 +53,7 @@ class AuthRoutes:
         key: str,
         value: str,
         max_age: int,
+        path: str = "/",
     ) -> None:
         """Set an HTTP-only authentication cookie on the response."""
         response.set_cookie(
@@ -62,6 +63,7 @@ class AuthRoutes:
             secure=True,
             samesite="none",
             max_age=max_age,
+            path=path,
         )
 
     def _set_auth_cookies(self, response: JSONResponse, token_data: dict[str, Any]) -> None:
@@ -73,9 +75,9 @@ class AuthRoutes:
         if isinstance(access_token, str):
             self._set_cookie(response, "access_token", access_token, self.ACCESS_COOKIE_MAX_AGE)
         if isinstance(refresh_token, str):
-            self._set_cookie(response, "refresh_token", refresh_token, self.REFRESH_COOKIE_MAX_AGE)
+            self._set_cookie(response, "refresh_token", refresh_token, self.REFRESH_COOKIE_MAX_AGE, path="/auth/refresh")
         if isinstance(id_token, str):
-            self._set_cookie(response, "id_token", id_token, self.ACCESS_COOKIE_MAX_AGE)
+            self._set_cookie(response, "id_token", id_token, self.ACCESS_COOKIE_MAX_AGE, path="/auth/logout")
 
     async def _request_tokens(self, data: dict[str, str]) -> dict[str, Any]:
         """Request tokens from AD provider using provided form data."""
@@ -201,6 +203,6 @@ class AuthRoutes:
             content={"logout_url": logout_url},
         )
         response.delete_cookie("access_token", path="/", secure=True, samesite="none")
-        response.delete_cookie("refresh_token", path="/", secure=True, samesite="none")
-        response.delete_cookie("id_token", path="/", secure=True, samesite="none")
+        response.delete_cookie("refresh_token", path="/auth/refresh", secure=True, samesite="none")
+        response.delete_cookie("id_token", path="/auth/logout", secure=True, samesite="none")
         return response

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -78,7 +78,7 @@ class AuthRoutes:
                 value=refresh_token,
                 httponly=True,
                 secure=True,
-                samesite=None,
+                samesite="none",
                 max_age=self.REFRESH_COOKIE_MAX_AGE,
                 path="/auth/refresh",
             )

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -94,7 +94,7 @@ class AuthRoutes:
                 secure=True,
                 samesite="none",
                 max_age=refresh_max_age,
-                path="/auth/refresh",
+                path="api/auth/refresh",
             )
 
         if isinstance(id_token, str):

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -80,7 +80,7 @@ class AuthRoutes:
                 secure=True,
                 samesite="none",
                 max_age=self.REFRESH_COOKIE_MAX_AGE,
-                path="/auth/refresh",
+                path="api/auth/refresh",
             )
         if isinstance(id_token, str):
             response.set_cookie(
@@ -90,7 +90,7 @@ class AuthRoutes:
                 secure=True,
                 samesite="none",
                 max_age=self.ACCESS_COOKIE_MAX_AGE,
-                path="/auth/logout",
+                path="api/auth/logout",
             )
 
     async def _request_tokens(self, data: dict[str, str]) -> dict[str, Any]:


### PR DESCRIPTION
fixed pathing for cookies to be included, now we only send access_token where it is needed.
RefreshToken is sent during /auth/refresh calls
idToken is sent during /auth/logout calls for logging out properly.