### PR TITLE
Sub Resource Integrity Attribute Missing #583

### DIFF
--- a/src/front_end/index.html
+++ b/src/front_end/index.html
@@ -9,7 +9,6 @@
   <body>
     <div id="app"></div>
     <script src="/env.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/front_end/package.json
+++ b/src/front_end/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-vue": "^9.33.0",
     "prettier": "^3.6.2",
     "vite": "^7.3.1",
+    "marked": "^18.0.3",
     "@vue/test-utils": "^2.4.10",
     "jsdom": "^29.1.1",
     "vitest": "^4.1.5"

--- a/src/front_end/src/composables/aiSummary.js
+++ b/src/front_end/src/composables/aiSummary.js
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue'
 import { useSearchMetadata } from '@/composables/useSearchMetadata'
 import { authFetch, API_PATHS } from '@/utils/api'
+import { marked } from 'marked'
 
 export function useAISummary(props = {}) {
   /* Unique pointer from metadata */
@@ -71,7 +72,7 @@ export function useAISummary(props = {}) {
       }
 
       aiSummary.value = summaryText
-      aiSummaryHtmlRaw.value = globalThis.marked ? globalThis.marked.parse(summaryText) : summaryText
+      aiSummaryHtmlRaw.value = marked.parse(summaryText)
       summaryPointer.value = requestPointers.join('|')
     } catch (error) {
       summaryError.value = error.message

--- a/src/front_end/src/composables/mdToPdf.js
+++ b/src/front_end/src/composables/mdToPdf.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { useSearchMetadata } from '@/composables/useSearchMetadata'
 import { authFetch, API_PATHS } from '@/utils/api'
+import { marked } from 'marked'
 
 export function useMdToPdf(props = {}) {
   /* Unique pointer from metadata */
@@ -64,7 +65,7 @@ export function useMdToPdf(props = {}) {
     }
 
     mergedMarkdown.value = markdownText
-    mergedHtmlRaw.value = globalThis.marked ? globalThis.marked.parse(markdownText) : markdownText
+    mergedHtmlRaw.value = marked.parse(markdownText)
     return markdownText
   }
 


### PR DESCRIPTION
One of the medium vulnerabilities in the owasp zap scan was "Sub Resurce Integrity Attribute Missing" for the use of <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>, the best solution use npm markedd

The visulatation is stil the same
<img width="2068" height="823" alt="image" src="https://github.com/user-attachments/assets/5eb35b8f-8823-4790-83eb-2ffcfc31c159" />

Tbh, I like this code better also