### PR TITLE
Fixing cookie refresh

### DIFF
--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -73,9 +73,25 @@ class AuthRoutes:
         if isinstance(access_token, str):
             self._set_cookie(response, "access_token", access_token, self.ACCESS_COOKIE_MAX_AGE)
         if isinstance(refresh_token, str):
-            self._set_cookie(response, "refresh_token", refresh_token, self.REFRESH_COOKIE_MAX_AGE)
+            response.set_cookie(
+                key="refresh_token",
+                value=refresh_token,
+                httponly=True,
+                secure=True,
+                samesite="none",
+                max_age=self.REFRESH_COOKIE_MAX_AGE,
+                path="/auth/refresh",
+            )
         if isinstance(id_token, str):
-            self._set_cookie(response, "id_token", id_token, self.ACCESS_COOKIE_MAX_AGE)
+            response.set_cookie(
+                key="id_token",
+                value=id_token,
+                httponly=True,
+                secure=True,
+                samesite="none",
+                max_age=self.ACCESS_COOKIE_MAX_AGE,
+                path="/auth/logout",
+            )
 
     async def _request_tokens(self, data: dict[str, str]) -> dict[str, Any]:
         """Request tokens from AD provider using provided form data."""
@@ -201,6 +217,6 @@ class AuthRoutes:
             content={"logout_url": logout_url},
         )
         response.delete_cookie("access_token", path="/", secure=True, samesite="none")
-        response.delete_cookie("refresh_token", path="/", secure=True, samesite="none")
-        response.delete_cookie("id_token", path="/", secure=True, samesite="none")
+        response.delete_cookie("refresh_token", path="/auth/refresh", secure=True, samesite="none")
+        response.delete_cookie("id_token", path="/auth/logout", secure=True, samesite="none")
         return response

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -66,7 +66,7 @@ class AuthRoutes:
 
     def _get_token_max_age(
         self,
-        token_data: dict[str, any],
+        token_data: dict[str, Any],
         key: str,
         fallback: int,
     ) -> int:

--- a/src/api/src/dmis_api/auth_routes.py
+++ b/src/api/src/dmis_api/auth_routes.py
@@ -64,14 +64,28 @@ class AuthRoutes:
             max_age=max_age,
         )
 
+    def _get_token_max_age(
+        self,
+        token_data: dict[str, any],
+        key: str,
+        fallback: int,
+    ) -> int:
+        """Get token max age from tokens form AD"""
+        max_age = token_data.get(key)
+        return max_age if isinstance(max_age, int) else fallback
+
     def _set_auth_cookies(self, response: JSONResponse, token_data: dict[str, Any]) -> None:
         """Set authentication cookies from token response data."""
         access_token = token_data.get("access_token")
         refresh_token = token_data.get("refresh_token")
         id_token = token_data.get("id_token")
 
+        access_max_age = self._get_token_max_age(token_data, "expires_in", self.ACCESS_COOKIE_MAX_AGE)
+        refresh_max_age = self._get_token_max_age(token_data, "refresh_expires_in", self.REFRESH_COOKIE_MAX_AGE)
+
         if isinstance(access_token, str):
-            self._set_cookie(response, "access_token", access_token, self.ACCESS_COOKIE_MAX_AGE)
+            self._set_cookie(response, "access_token", access_token, access_max_age)
+
         if isinstance(refresh_token, str):
             response.set_cookie(
                 key="refresh_token",
@@ -79,9 +93,10 @@ class AuthRoutes:
                 httponly=True,
                 secure=True,
                 samesite="none",
-                max_age=self.REFRESH_COOKIE_MAX_AGE,
+                max_age=refresh_max_age,
                 path="/auth/refresh",
             )
+
         if isinstance(id_token, str):
             response.set_cookie(
                 key="id_token",
@@ -89,7 +104,7 @@ class AuthRoutes:
                 httponly=True,
                 secure=True,
                 samesite="none",
-                max_age=self.ACCESS_COOKIE_MAX_AGE,
+                max_age=access_max_age,
                 path="/auth/logout",
             )
 

--- a/src/front_end/src/utils/api.js
+++ b/src/front_end/src/utils/api.js
@@ -43,14 +43,33 @@ export const API_PATHS = {
  * @param {RequestInit} [options]
  * @returns {Promise<Response>}
  */
-export function apiFetch(url, options = {}) {
-  return fetch(url, {
+export async function apiFetch(url, options = {}) {
+  const requestOptions = {
     credentials: 'include',
     ...options,
     headers: {
       ...(options.headers ?? {})
     }
+  }
+
+  let response = await fetch(url, requestOptions)
+
+  if (response.status !== 401 || url === API_PATHS.authRefresh || url === API_PATHS.authLogout) {
+    return response
+  }
+
+  const refreshResponse = await fetch(API_PATHS.authRefresh, {
+    method: 'POST',
+    credentials: 'include'
   })
+
+  if (!refreshResponse.ok) {
+    window.location.href = '/login'
+    return response
+  }
+
+  response = await fetch(url, requestOptions)
+  return response
 }
 
 /* causes all previos authFetch calls into apiFetch */


### PR DESCRIPTION
Fixed cookies to work with lifespan for AD tokens.
access_token & id_token Lifespan: 5 min
refresh_token lifespan: 30min

How it now works:
If a user is idle and doesn't do any api calls for let's say 12 min and then searches something, the flow is like follows:

We get an error 401 which we handle (not seen) we try to refresh tokens which happens due to 12 < 30 (refresh lifespan), the new tokens are updated from current time + 5 min for access_token & id_token, + 30 for refresh_token.

If the user is afk or idle doing nothing for 30+ minutes from previous refresh then the refresh token dies (currently) I am working on fixing this in a different branch, where we track activity, to make sure active users aren't forced logged out.