### PR TITLE
fix(ci): stub CONCONFLUENDE_CHECK_AUTH_URL in Confluence collector tests

### DIFF
--- a/src/connectors/confluence/README.md
+++ b/src/connectors/confluence/README.md
@@ -18,6 +18,7 @@ The following should be exported in local environment:
     #OAuth scopes to request
     CONCONFLUENCE_SCOPES=read:space:confluence read:page:confluence offline_access
     CONCONFLUENCE_CONNECT_SERVICE_CALLBACK:callback for token
+    CONCONFLUENDE_CHECK_AUTH_URL: #e.g. https://api.atlassian.com/oauth/token/accessible-resources
 
 
 ## Atlassian developer console setup

--- a/src/connectors/confluence/test/test_collector_api.py
+++ b/src/connectors/confluence/test/test_collector_api.py
@@ -19,6 +19,8 @@ _FAKE_OAUTH_ENV: dict[str, str] = {
     "CONCONFLUENCE_TOKEN_URL": "https://location/oauth/token",
     "CONCONFLUENCE_SCOPES": "read:space:confluence,read:page:confluence,offline_access",
     "CONCONFLUENCE_CONNECT_SERVICE_CALLBACK": "https://somelocation/callback",
+    # Must match ``read_env_variable`` name in ``collector_api`` (currently CONCONFLUENDE_…).
+    "CONCONFLUENDE_CHECK_AUTH_URL": "https://location/token/validate",
 }
 
 

--- a/src/connectors/confluence/test/test_collector_api.py
+++ b/src/connectors/confluence/test/test_collector_api.py
@@ -19,7 +19,6 @@ _FAKE_OAUTH_ENV: dict[str, str] = {
     "CONCONFLUENCE_TOKEN_URL": "https://location/oauth/token",
     "CONCONFLUENCE_SCOPES": "read:space:confluence,read:page:confluence,offline_access",
     "CONCONFLUENCE_CONNECT_SERVICE_CALLBACK": "https://somelocation/callback",
-    # Must match ``read_env_variable`` name in ``collector_api`` (currently CONCONFLUENDE_…).
     "CONCONFLUENDE_CHECK_AUTH_URL": "https://location/token/validate",
 }
 


### PR DESCRIPTION
# summary
- Add `CONCONFLUENDE_CHECK_AUTH_URL` to the test fake env (`_FAKE_OAUTH_ENV`) so `API()` can be constructed without raising `KeyError`.
- Fixes failing `unittest_env` / Tox after `collector_api` started reading this variable during initialization.
## background
CI failure: [failed job](https://github.com/Studentprojekt-KCL/document_management_system/actions/runs/25908405817/job/76147110177) — three failures in `test_collector_api.py` when `read_env_variable("CONCONFLUENDE_CHECK_AUTH_URL")` runs but the mock dict had no such key.
## test plan
- `python -m pytest src/connectors/confluence/test/test_collector_api.py`
- (optional) `tox -e unittest_env`
## follow-up (separate)
Consider reviewing the production env name `CONCONFLUENDE_CHECK_AUTH_URL` in `collector_api` versus the other `CONCONFLUENCE_*` variables and docs/README/deploy so operators get a consistent variable name.
