### PR TITLE
Fix SharePoint connector to satisfy the connector gateway contract

### DIFF
--- a/src/connectors/sharepoint/src/interfacer_sharepoint.py
+++ b/src/connectors/sharepoint/src/interfacer_sharepoint.py
@@ -44,6 +44,19 @@ class SharePoint:
         file_type_resource = get_file_resource()
         self.file_extensions = [t.get("extension") for t in file_type_resource]
         self.extension_descriptions = {t.get("extension"): t.get("description") for t in file_type_resource}
+        self.defined_fields = dict.fromkeys(
+            [
+                "unique_pointer",
+                "name",
+                "size",
+                "type",
+                "source_system",
+                "last_edit_date",
+                "clickable_url",
+                "content",
+                *determine_file_type("", self.file_extensions, self.extension_descriptions),
+            ]
+        )
 
     @staticmethod
     async def _request_with_retry(ctx: _HttpCtx, url: str, method: str = "get", **kwargs: Any) -> httpx.Response:
@@ -302,6 +315,15 @@ class SharePoint:
                 result["content"] = None
 
         return result
+
+    async def verify_token(self, token: str | None) -> bool:
+        """Return True if the token grants access to the Graph API, False otherwise."""
+        if token is None:
+            return False
+        async with httpx.AsyncClient(cookies={}) as client:
+            ctx = _HttpCtx(client, asyncio.Semaphore(1), token)
+            response = await self._request_with_retry(ctx, f"{self.graph_base}/me", timeout=REQUEST_TIMEOUT)
+        return response.status_code == httpx.codes.OK
 
     async def get_files(
         self,

--- a/src/connectors/sharepoint/src/sharepoint_collector_api.py
+++ b/src/connectors/sharepoint/src/sharepoint_collector_api.py
@@ -20,6 +20,7 @@ from shared_functions.initialisation_tools import read_env_variable, read_port
 from shared_functions.signing_tools import sign_encode_state, validate_decode_state
 
 MS_LOGIN_BASE = "https://login.microsoftonline.com"
+BEARER_PREFIX = "Bearer "
 
 
 class API:
@@ -39,7 +40,9 @@ class API:
 
         self.app.add_exception_handler(RequestValidationError, self.validation_exception_handler)
         self.app.add_api_route("/get_files", self.get_files, methods=["POST"])
-        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index, methods=["GET"])
+        self.app.add_api_route("/stream_files_to_index", self.stream_files_to_index, methods=["POST"])
+        self.app.add_api_route("/validate_token", self.validate_token, methods=["GET"])
+        self.app.add_api_route("/defined_fields", self.defined_fields, methods=["GET"])
         self.app.add_api_route("/auth_user", self.auth_user, methods=["GET"])
         self.app.add_api_route("/callback", self.callback, methods=["GET"])
         self.app.add_api_route("/refresh_token", self.refresh_token, methods=["GET"])
@@ -70,18 +73,32 @@ class API:
             "file_pointers": ["<FILE_PTR>"]
             }'
         """
+        token = x_sharepoint_token.removeprefix(BEARER_PREFIX).strip() if x_sharepoint_token else None
         return await self.sharepoint_instance.get_files(
-            file_pointers.get("file_pointers", []), x_sharepoint_token, include_content, include_last_edit_date
+            file_pointers.get("file_pointers", []), token, include_content, include_last_edit_date
         )
 
     def stream_files_to_index(
-        self, subdata: str | None = None, x_sharepoint_token: Annotated[str | None, Header()] = None
+        self,
+        body: dict[str, str | None] | None = None,
+        x_sharepoint_token: Annotated[str | None, Header()] = None,
     ) -> StreamingResponse:
         """Endpoint streaming all qualifying documents for indexing."""
+        subdata: str | None = body.get("subdata") if isinstance(body, dict) else None
+        token = x_sharepoint_token.removeprefix(BEARER_PREFIX).strip() if x_sharepoint_token else None
         return StreamingResponse(
-            self.sharepoint_instance.stream_files_to_index(subdata, x_sharepoint_token),
+            self.sharepoint_instance.stream_files_to_index(subdata, token),
             media_type="application/octet-stream",
         )
+
+    async def validate_token(self, x_sharepoint_token: Annotated[str | None, Header()] = None) -> JSONResponse:
+        """Verify that the provided token can access the Microsoft Graph API."""
+        token = x_sharepoint_token.removeprefix(BEARER_PREFIX).strip() if x_sharepoint_token else None
+        return JSONResponse(content={"valid": await self.sharepoint_instance.verify_token(token)}, status_code=200)
+
+    def defined_fields(self) -> list[str]:
+        """Return the list of field keys this connector can deliver."""
+        return list(self.sharepoint_instance.defined_fields.keys())
 
     def auth_user(self) -> JSONResponse:
         """Redirect user to Microsoft OAuth login."""


### PR DESCRIPTION
The SharePoint connector was missing two endpoints required by the gateway (/validate_token, /defined_fields), used the wrong HTTP method and parameter transport for /stream_files_to_index, and passed auth tokens to the Graph API with a double "Bearer " prefix.

- Add /validate_token: calls GET /me on the Graph API, returns {"valid": bool}
- Add /defined_fields: exposes the full set of fields the connector can return
- Change /stream_files_to_index from GET to POST; read subdata from the JSON body instead of a query parameter, matching the contract expected by the search engine's streaming client
- Strip the "Bearer " prefix from incoming tokens in /get_files, /stream_files_to_index, and /validate_token — the gateway forwards tokens with the prefix already included, and the interfacer prepends it again when building the Authorization header, resulting in 401s from Graph API on every authenticated call